### PR TITLE
Import Security Policy from Wiki

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Second Life Security Policy
+Issues pertaining to the security of Second Life should be sent to Linden Lab via special mechanism described below.  Please help us keep Second Life secure by ensuring that possible security exploits aren't broadly advertised before a fix is available.
+
+## So just what constitutes a security issue?
+If an issue poses any of the following threats to Second Life, its Residents or content, then it is an exploit and should be reported:
+
+* Exposes real life Resident identity without consent
+* Destroys content
+* Permits unauthorized access to Second Life/Linden Lab resources
+* Compromises a client or server host subjecting it to remote control
+
+**When reporting an exploit, please provide as much detail as possible**, Including the environment used (e.g. Windows XP Service Pack 2, Nvidia 6800 etc ) and the complete reproduction case. Linden Lab offers a L$10,000 bounty for each previously unknown exploit that can be verified.  Please report issues as soon as they are discovered!
+
+## Filing issues
+There are two ways to file security reports:
+*  In the SEC project on [jira.secondlife.com](http://jira.secondlife.com) (PREFERRED). It's **VERY IMPORTANT** that you file issues in the SEC project, which is the only project set up so that only the reporter and Linden Lab can view the issue.
+*  Via email: [security@lindenlab.com](mailto:security@lindenlab.com)
+
+> ⚠️ **Warning:** The SEC project (and security mailing list) is **ONLY for reporting security exploits** that might compromise a Residents identity or the Second Life Grid. All other requests including account issues and account security via this address will **not** be addressed.
+
+## For other issues:
+*  If you believe your account has been breached please attempt to change your password immediately and also  [contact support](http://secondlife.com/community/support.php).
+*  If you are experiencing some other problem, please [contact support](http://secondlife.com/community/support.php).
+*  See [Bug Tracker](https://wiki.secondlife.com/wiki/Bug_Tracker) for information about filing non-security issues.


### PR DESCRIPTION
The following PR is a markdown equivalent of the https://wiki.secondlife.com/wiki/Security_issues page.

Adding this will add a security policy link to the sidebar of all Second Life repos, like so:
![image](https://user-images.githubusercontent.com/6495643/204105589-8369d1d0-ef2a-4ca7-82a1-5bfa4f1c9e76.png)
