### PR TITLE
Update security policy to fit with deprecation of Jira

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If an issue poses any of the following threats to Second Life, its Residents or 
 
 * Exposes real life Resident identity without consent
 * Destroys content
-* Permits unauthorized access to Second Life/Linden Lab resources
+* Permits unauthorized access to Second Life / Linden Lab resources
 * Compromises a client or server host subjecting it to remote control
 
 **When reporting an exploit, please provide as much detail as possible**, Including the environment used (e.g. Windows XP Service Pack 2, Nvidia 6800 etc ) and the complete reproduction case. Linden Lab offers a L$10,000 bounty for each previously unknown exploit that can be verified.  Please report issues as soon as they are discovered!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,6 @@ If an issue poses any of the following threats to Second Life, its Residents or 
 
 ## Filing issues
 There are two ways to file security reports:
-*  In the SEC project on [jira.secondlife.com](http://jira.secondlife.com) (PREFERRED). It's **VERY IMPORTANT** that you file issues in the SEC project, which is the only project set up so that only the reporter and Linden Lab can view the issue.
 *  Via email: [security@lindenlab.com](mailto:security@lindenlab.com)
 
 > [!WARNING]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,8 @@ There are two ways to file security reports:
 *  In the SEC project on [jira.secondlife.com](http://jira.secondlife.com) (PREFERRED). It's **VERY IMPORTANT** that you file issues in the SEC project, which is the only project set up so that only the reporter and Linden Lab can view the issue.
 *  Via email: [security@lindenlab.com](mailto:security@lindenlab.com)
 
-> ⚠️ **Warning:** The SEC project (and security mailing list) is **ONLY for reporting security exploits** that might compromise a Residents identity or the Second Life Grid. All other requests including account issues and account security via this address will **not** be addressed.
+> [!WARNING]
+> The SEC project (and security mailing list) is **ONLY for reporting security exploits** that might compromise a Residents identity or the Second Life Grid. All other requests including account issues and account security via this address will **not** be addressed.
 
 ## For other issues:
 *  If you believe your account has been breached please attempt to change your password immediately and also  [contact support](http://secondlife.com/community/support.php).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ If an issue poses any of the following threats to Second Life, its Residents or 
 * Permits unauthorized access to Second Life / Linden Lab resources
 * Compromises a client or server host subjecting it to remote control
 
-**When reporting an exploit, please provide as much detail as possible**, Including the environment used (e.g. Windows XP Service Pack 2, Nvidia 6800 etc ) and the complete reproduction case. Linden Lab offers a L$10,000 bounty for each previously unknown exploit that can be verified.  Please report issues as soon as they are discovered!
+**When reporting an exploit, please provide as much detail as possible**, Including the environment used (e.g. Windows XP Service Pack 2, Nvidia 6800, etc) and the complete reproduction case. Linden Lab offers a L$10,000 bounty for each previously unknown exploit that can be verified.  Please report issues as soon as they are discovered!
 
 ## Filing issues
 There are two ways to file security reports:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ There are two ways to file security reports:
 *  Via email: [security@lindenlab.com](mailto:security@lindenlab.com)
 
 > [!WARNING]
-> The SEC project (and security mailing list) is **ONLY for reporting security exploits** that might compromise a Residents identity or the Second Life Grid. All other requests including account issues and account security via this address will **not** be addressed.
+> The Security mailing list is **ONLY for reporting security exploits** that might compromise a Residents identity or the Second Life Grid. All other requests including account issues and account security via this address will **not** be addressed.
 
 ## For other issues:
 *  If you believe your account has been breached please attempt to change your password immediately and also  [contact support](http://secondlife.com/community/support.php).


### PR DESCRIPTION
## This change set does three things:
1. Cosmetic change - Change the `:warning: **WARNING**` generic markdown to github markdown that uses `[!WARNING]`, which puts more emphasis on the warning.
2. Cosmetic change - Clean up some of the textual formatting without changing the wording.
3. Remove the instructions to report to Jira, as this can indirectly cause people to post security vulnerabilities on the Canny, as the link to the Jira currently redirects to Canny.

## Recommendations outside of my control:
It may be worth creating a "Security" repo solely for collecting security issues. This is natively supported by Github and is documented here: https://docs.github.com/en/enterprise-cloud@latest/code-security/security-advisories/working-with-repository-security-advisories/creating-a-repository-security-advisory
If this is done, the change that got rid of the instructions for Jira can be reverted and changed to instruct users to that repo instead.
Assignment of a CVE or CWE is entirely optional, and from what I understand, is only really useful if the issue is made public, which making SECs public would also be optional.
Just a thought on providing additional means for people to report security issues!

Additionally, https://wiki.secondlife.com/wiki/Security_issues should be updated with similar instructions as it still instructs users to submit to the Jira, which is now the Canny. I cannot edit this as I do not have the appropriate permissions on the wiki.